### PR TITLE
Update scaleidentifier.js

### DIFF
--- a/scaleidentifier.js
+++ b/scaleidentifier.js
@@ -319,8 +319,8 @@ function createIndicators(frets) {
 
 function removeIndicators(frets) {
     for (let i = beforeFrets; i > frets; i--) {
-        document.getElementById(`fret${i}`).remove();
-        console.log(`fret${i} indicator removal`);
+        document.getElementById(`fretno${i}`).remove();
+        console.log(`fretno${i} indicator removal`);
     }
 }
 


### PR DESCRIPTION
fixed naming for fret-indicators children which caused .remove() to create a bug